### PR TITLE
Create environment.yaml

### DIFF
--- a/envs/environment.yaml
+++ b/envs/environment.yaml
@@ -1,0 +1,25 @@
+name: irena-msr
+channels:
+- conda-forge
+dependencies:
+- python>=3.8
+
+- cdsapi
+- geopandas
+- geocube
+- matplotlib
+- numpy<=1.21
+- netCDF4
+- pandas
+- pyproj
+- pvlib-python
+- rasterio
+- richdem
+- rioxarray
+- rasterstats
+- scipy
+- openpyxl
+- shapely
+- Tslearn
+- xarray
+- xarray-spatial


### PR DESCRIPTION
While trying to install the MSR tool I encountered some difficulties and incompatabilities (e.g. `numpy` with `numba`). Also the list of libraries required for running the scripts is incomplete (e.g. `cdsapi` is missing).

I've created an `environment.yaml` file which can be used with e.g. Anaconda or mamba environment manager:

```
conda env create -f envs/environment.yaml

mamba env create -f envs/environment.yaml
```

to make setup and installation significantly easier.